### PR TITLE
Some bug fix and type extension for Vector and Matrix

### DIFF
--- a/Matrix.cpp
+++ b/Matrix.cpp
@@ -54,6 +54,10 @@ Matrix::Matrix(int r) : Vector(r*r)
 	triangle = false;
 }
 
+Matrix::Matrix(double* data, int d) :Vector(data, d*d) {
+
+}
+
 
 
 
@@ -92,7 +96,7 @@ void Matrix::readMatrix(char* filename)
 	}
 }
 
-void Matrix::writeMatrix(char* filename)
+void Matrix::writeMatrix(const char* filename)
 {
 	ofstream file(filename);
 	int i,j;
@@ -125,6 +129,7 @@ void Matrix::writeBin(string filename)
 /* Get Row */
 Vector& Matrix::operator[](int i){
 	absbuffer.get().data = data + m*i;
+	absbuffer.get().n = m;
 	return absbuffer.next();
 }
 

--- a/Matrix.h
+++ b/Matrix.h
@@ -4,21 +4,22 @@ class Matrix :
 	public Vector
 {
 public:
-	int m;
-	int r;
+	int m;	// Number of dimensions
+	int r;	// Number of rows
 	int triangle;
 
 
 	Matrix(void);
 	Matrix(int d);
 	Matrix(int r,int m,int real=1);			// refcount
+	Matrix(double* data, int d);		// Construct a Matrix from a double array. Row major.
 	Matrix(Matrix&& mat);			// Move
 	Matrix(const Matrix& mat);			// Copy
 									// 1 is standart , 2  is persistent , 0 is abstract
 	~Matrix(void);
 	
 	void readMatrix(char* filename);
-	void writeMatrix(char* filename);
+	void writeMatrix(const char* filename);
 
 	
 

--- a/Vector.cpp
+++ b/Vector.cpp
@@ -149,8 +149,10 @@ Vector::Vector(Vector&& v)
 	data  = v.data;
 	v.data = NULL;
 	v.n = 0;
-	v.type = 0; // No longer valid vector
-	type = 1; // Owns the resource
+	type = v.type;
+	if (v.type == 1) {
+		v.type = 0; // No longer valid vector
+	}
 }
 
 Vector::Vector(const Vector& v)
@@ -371,7 +373,7 @@ Vector Vector::unique()
 	return res;
 }
 
-Vector& Vector::operator*(double scalar)
+Vector& Vector::operator*(double scalar) const
 {
 	Vector& r = buffer.get();
 	for(int i=0;i<n;i++)
@@ -379,7 +381,7 @@ Vector& Vector::operator*(double scalar)
 	return buffer.next();
 }
 
-Vector& Vector::operator-(Vector& v)
+Vector& Vector::operator-(const Vector& v) const
 {
 	Vector& r = buffer.get();
 	/*if (CBLAS)
@@ -394,7 +396,7 @@ Vector& Vector::operator-(Vector& v)
 	return buffer.next();
 }
 
-Vector& Vector::operator+(Vector& v)
+Vector& Vector::operator+(const Vector& v) const
 {
 	Vector& r = buffer.get();
 	/*if (CBLAS)
@@ -453,7 +455,7 @@ Vector& Vector::operator>=(double scalar)
 }
 
 
-Vector& Vector::operator+(double scalar)
+Vector& Vector::operator+(double scalar) const
 {
 	Vector& r = buffer.get();
 	for (int i = 0; i<n; i++)
@@ -461,7 +463,7 @@ Vector& Vector::operator+(double scalar)
 	return buffer.next();
 }
 
-Vector& Vector::operator-(double scalar)
+Vector& Vector::operator-(double scalar) const
 {
 	Vector& r = buffer.get();
 	for (int i = 0; i<n; i++)

--- a/Vector.h
+++ b/Vector.h
@@ -62,7 +62,7 @@ public:
 	int		operator()(int i);	 // Return integer
 	double operator*(Vector& v); // Inner product
 	//Vector operator*(Matrix& m); //
-	Vector& operator-(Vector& v); // Subtraction
+	Vector& operator-(const Vector& v) const; // Subtraction
 	Vector& operator/(Matrix& mat); // Matrix division
 	Vector& operator/(Vector& vec); // Element-wise division
 	void operator=(const Vector& v); // Assignment 
@@ -79,10 +79,10 @@ public:
 	void operator*=(const Vector& v); // Inplace addition works on arbitrary size
 
 	
-	Vector& operator*(double scalar); // Scaling
-	Vector& operator+(double scalar); // Add scalar to all elements
-	Vector& operator-(double scalar); // Subtract scalar to all elements
-	Vector& operator+(Vector& v);	// Summation
+	Vector& operator*(double scalar) const; // Scaling
+	Vector& operator+(double scalar) const; // Add scalar to all elements
+	Vector& operator-(double scalar) const; // Subtract scalar to all elements
+	Vector& operator+(const Vector& v) const;	// Summation
 	Vector& operator/(double scalar); // Elementwise comparison
 	Vector& operator<(double scalar); // Elementwise comparison
 	Vector& operator>(double scalar);


### PR DESCRIPTION
Changed operator-,+ to support const;
fixed Vector's move constructor for abstract type;
fixed Matrix's operator[] doesn't set Vector::n.